### PR TITLE
Implement tile-based radio buttons

### DIFF
--- a/components/AnswerTile.tsx
+++ b/components/AnswerTile.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, forwardRef } from 'react';
+
+export interface AnswerTileProps {
+  label: string;
+  icon?: ReactNode;
+  value: string | number;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * Render a selectable tile acting as a radio button.
+ */
+const AnswerTile = forwardRef<HTMLLabelElement, AnswerTileProps>(
+  ({ label, icon, value, selected, onSelect }, ref) => {
+    return (
+      <label
+        ref={ref}
+        role="radio"
+        aria-checked={selected}
+        tabIndex={0}
+        className={
+          `w-full max-w-[300px] h-[96px] px-4 py-3 rounded-[8px] border ` +
+          `flex flex-col items-center justify-center transition-colors ` +
+          `border-primary text-primary ` +
+          `${selected ? 'bg-selected text-onSelected' : 'bg-transparent'} ` +
+          `${!selected ? 'hover:shadow-md cursor-pointer' : ''} ` +
+          `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary`
+        }
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+      >
+        <input
+          type="radio"
+          className="hidden"
+          value={value}
+          checked={selected}
+          onChange={() => {}}
+        />
+        {icon && <span className="mb-1">{icon}</span>}
+        <span>{label}</span>
+      </label>
+    );
+  }
+);
+
+export default AnswerTile;

--- a/components/GenderQuestionExample.tsx
+++ b/components/GenderQuestionExample.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { FaMars, FaVenus, FaGenderless, FaQuestion } from 'react-icons/fa';
+import Question from './Question';
+
+export default function GenderQuestionExample() {
+  const [gender, setGender] = useState<string | number>('M');
+
+  const options = [
+    { label: 'M', icon: <FaMars />, value: 'M' },
+    { label: 'F', icon: <FaVenus />, value: 'F' },
+    { label: 'Altro', icon: <FaGenderless />, value: 'X' },
+    { label: 'Pnts', icon: <FaQuestion />, value: 'N' },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <p className="font-semibold">Seleziona il tuo genere:</p>
+      <Question
+        question="Genere"
+        options={options}
+        selectedValue={gender}
+        onChange={setGender}
+      />
+      <p className="text-sm text-gray-600">Valore selezionato: {gender}</p>
+    </div>
+  );
+}

--- a/components/Question.tsx
+++ b/components/Question.tsx
@@ -1,0 +1,53 @@
+import React, { useRef } from 'react';
+import AnswerTile, { AnswerTileProps } from './AnswerTile';
+
+export interface QuestionProps {
+  question: string;
+  options: Array<Omit<AnswerTileProps, 'selected' | 'onSelect'>>;
+  selectedValue: string | number;
+  onChange: (value: string | number) => void;
+}
+
+/**
+ * Display a question with selectable answer tiles.
+ */
+export default function Question({
+  question,
+  options,
+  selectedValue,
+  onChange,
+}: QuestionProps) {
+  const itemsRef = useRef<(HTMLLabelElement | null)[]>([]);
+
+  const focusItem = (index: number) => {
+    const el = itemsRef.current[index];
+    if (el) el.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const currentIndex = itemsRef.current.findIndex((el) => el === document.activeElement);
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = currentIndex === options.length - 1 ? 0 : currentIndex + 1;
+      focusItem(next);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = currentIndex <= 0 ? options.length - 1 : currentIndex - 1;
+      focusItem(prev);
+    }
+  };
+
+  return (
+    <div role="radiogroup" className="flex flex-wrap gap-4" onKeyDown={handleKeyDown}>
+      {options.map((opt, idx) => (
+        <AnswerTile
+          key={opt.value}
+          {...opt}
+          selected={selectedValue === opt.value}
+          onSelect={() => onChange(opt.value)}
+          ref={(el) => (itemsRef.current[idx] = el)}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AnswerTile` component for selectable radio-like tiles
- add `Question` component to arrange tiles and handle keyboard navigation
- provide `GenderQuestionExample` showcasing four options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d14a8d4608333946dccfb58c87f3f