### PR TITLE
Add interactive form building blocks

### DIFF
--- a/components/AvatarBuilder.tsx
+++ b/components/AvatarBuilder.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+
+export interface AvatarBuilderProps {
+  selectedTraits: string[];
+}
+
+interface StickerPos {
+  x: number;
+  y: number;
+}
+
+export default function AvatarBuilder({ selectedTraits }: AvatarBuilderProps) {
+  const prefersReduced = useReducedMotion();
+
+  const positions = useMemo<StickerPos[]>(() => {
+    const taken: StickerPos[] = [];
+    function randomPos(): StickerPos {
+      const r = 70; // radius inside circle
+      return {
+        x: Math.random() * r * 2 - r,
+        y: Math.random() * r * 2 - r,
+      };
+    }
+    for (let i = 0; i < selectedTraits.length && i < 8; i++) {
+      let pos = randomPos();
+      let attempts = 0;
+      while (
+        taken.some((p) => Math.hypot(p.x - pos.x, p.y - pos.y) < 24) &&
+        attempts < 10
+      ) {
+        pos = randomPos();
+        attempts++;
+      }
+      taken.push(pos);
+    }
+    return taken;
+  }, [selectedTraits]);
+
+  return (
+    <div className="w-40 h-40 rounded-full bg-gray-200 relative flex items-center justify-center text-center overflow-hidden">
+      {selectedTraits.length === 0 && (
+        <span className="text-sm px-2">Add traits to shape your Mate!</span>
+      )}
+      <AnimatePresence>
+        {positions.map((pos, idx) => (
+          <motion.span
+            key={selectedTraits[idx]}
+            className="absolute text-xl"
+            style={{ left: '50%', top: '50%', transform: `translate(${pos.x}px, ${pos.y}px)` }}
+            initial={prefersReduced ? false : { scale: 0.6, opacity: 0 }}
+            animate={prefersReduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            ⭐
+          </motion.span>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/ConfettiBurst.ts
+++ b/components/ConfettiBurst.ts
@@ -1,0 +1,61 @@
+export function fire(x: number, y: number) {
+  if (typeof document === 'undefined') return;
+
+  const canvas = document.createElement('canvas');
+  canvas.style.position = 'fixed';
+  canvas.style.left = '0';
+  canvas.style.top = '0';
+  canvas.style.pointerEvents = 'none';
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  document.body.appendChild(canvas);
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const particles: Array<{
+    x: number;
+    y: number;
+    dx: number;
+    dy: number;
+    size: number;
+    life: number;
+    color: string;
+  }> = [];
+
+  const colors = ['#34d399', '#60a5fa', '#a78bfa', '#f472b6', '#facc15'];
+  for (let i = 0; i < 25; i++) {
+    particles.push({
+      x,
+      y,
+      dx: (Math.random() - 0.5) * 6,
+      dy: (Math.random() - 1.5) * 6,
+      size: Math.random() * 6 + 4,
+      life: 400,
+      color: colors[i % colors.length],
+    });
+  }
+
+  let prev = performance.now();
+  function draw(time: number) {
+    const dt = time - prev;
+    prev = time;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach((p) => {
+      p.x += p.dx;
+      p.y += p.dy;
+      p.dy += 0.1;
+      p.life -= dt;
+      ctx.fillStyle = p.color;
+      ctx.fillRect(p.x, p.y, p.size, p.size);
+    });
+
+    if (particles.some((p) => p.life > 0)) {
+      requestAnimationFrame(draw);
+    } else {
+      document.body.removeChild(canvas);
+    }
+  }
+  requestAnimationFrame(draw);
+}

--- a/components/MatchProgress.tsx
+++ b/components/MatchProgress.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export interface MatchProgressProps {
+  selectedCount: number;
+  total: number;
+}
+
+export default function MatchProgress({ selectedCount, total }: MatchProgressProps) {
+  const percent = total ? (selectedCount / total) * 100 : 0;
+  return (
+    <div className="sticky top-0 left-0 w-full h-1 bg-gray-200 z-50">
+      <motion.div
+        className="h-full"
+        style={{ background: 'linear-gradient(90deg, #3b82f6, #6366f1)', backgroundSize: '200% 100%' }}
+        animate={{ width: `${percent}%`, backgroundPosition: '100% 0' }}
+        transition={{ ease: 'easeInOut', duration: 0.3 }}
+      />
+    </div>
+  );
+}

--- a/components/Question.tsx
+++ b/components/Question.tsx
@@ -1,16 +1,13 @@
 import React, { useRef } from 'react';
-import AnswerTile, { AnswerTileProps } from './AnswerTile';
+import AnswerTile from './AnswerTile';
 
 export interface QuestionProps {
   question: string;
-  options: Array<Omit<AnswerTileProps, 'selected' | 'onSelect'>>;
-  selectedValue: string | number;
-  onChange: (value: string | number) => void;
+  options: { label: string; icon: React.ReactNode; value: string }[];
+  selectedValue: string;
+  onChange: (value: string) => void;
 }
 
-/**
- * Display a question with selectable answer tiles.
- */
 export default function Question({
   question,
   options,
@@ -38,11 +35,12 @@ export default function Question({
   };
 
   return (
-    <div role="radiogroup" className="flex flex-wrap gap-4" onKeyDown={handleKeyDown}>
+    <div role="radiogroup" aria-label={question} className="flex flex-wrap gap-4" onKeyDown={handleKeyDown}>
       {options.map((opt, idx) => (
         <AnswerTile
           key={opt.value}
-          {...opt}
+          label={opt.label}
+          icon={opt.icon}
           selected={selectedValue === opt.value}
           onSelect={() => onChange(opt.value)}
           ref={(el) => (itemsRef.current[idx] = el)}

--- a/components/QuestionBlock.tsx
+++ b/components/QuestionBlock.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import AnswerTile from './AnswerTile';
+
+export interface QuestionBlockProps {
+  title: string;
+  options: { label: string; icon: React.ReactNode; value: string }[];
+  selectedValue: string;
+  onChange: (val: string) => void;
+}
+
+export default function QuestionBlock({
+  title,
+  options,
+  selectedValue,
+  onChange,
+}: QuestionBlockProps) {
+  return (
+    <div aria-label={title} role="radiogroup" className="space-y-4">
+      <p className="font-semibold text-lg">{title}</p>
+      <motion.div
+        className="flex flex-wrap gap-4"
+        initial="hidden"
+        animate="visible"
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.05 } },
+        }}
+      >
+        {options.map((opt) => (
+          <motion.div
+            key={opt.value}
+            variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }}
+          >
+            <AnswerTile
+              label={opt.label}
+              icon={opt.icon}
+              selected={selectedValue === opt.value}
+              onSelect={() => onChange(opt.value)}
+            />
+          </motion.div>
+        ))}
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a canvas `ConfettiBurst` helper
- rebuild `AnswerTile` with framer-motion and confetti on click
- create `QuestionBlock` with staggered entrance
- add sticky top `MatchProgress` bar
- implement `AvatarBuilder` that places animated stickers
- update existing `Question` component to use new `AnswerTile`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d18b97f2c83339011da160733195b